### PR TITLE
change the link in website's button to our new domain.

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
                 Not officially affiliated with NIOS. <span class="emoji">😊</span>
             </p>
             <div class="button-container">
-                <a href="https://nios-students.pages.dev/" class="button-with-icon" target="_blank" rel="noopener">
+                <a href="https://nios-unofficial.info/" class="button-with-icon" target="_blank" rel="noopener">
                     <img src="img/website_logo.png" class="button-image" alt="Website Logo">
                     Our Website
                 </a>


### PR DESCRIPTION
Updated website button links to redirect users from legacy domains to the new primary domain, nios-unofficial.info, ensuring seamless migration and future-proofing the user experience.